### PR TITLE
005_fault_tolerance

### DIFF
--- a/exercises/src/main/java/com/lightbend/akkassembly/QualityAssurance.java
+++ b/exercises/src/main/java/com/lightbend/akkassembly/QualityAssurance.java
@@ -1,22 +1,32 @@
 package com.lightbend.akkassembly;
 
 import akka.NotUsed;
+import akka.japi.function.Function;
+import akka.stream.ActorAttributes;
+import akka.stream.Supervision;
 import akka.stream.javadsl.Flow;
 
 class QualityAssurance {
     private final Flow<UnfinishedCar, Car, NotUsed> inspect;
 
     QualityAssurance() {
-        this.inspect = Flow.of(UnfinishedCar.class).
-                filter(this::isValid)
-                .map(unfinishedCar ->
-                        new Car(new SerialNumber(),
+        Function<Throwable, Supervision.Directive> decider = exception -> {
+            return (exception instanceof CarFailedInspection ? Supervision.resume(): Supervision.stop());
+        };
+
+        this.inspect = Flow.of(UnfinishedCar.class)
+                .map(unfinishedCar -> {
+                    if (isValid(unfinishedCar)) {
+                        return new Car(new SerialNumber(),
                                 unfinishedCar.getColor().get(),
                                 unfinishedCar.getEngine().get(),
                                 unfinishedCar.getWheels(),
                                 unfinishedCar.getUpgrade()
-                        )
-                );
+                        );
+                    }
+                    throw new CarFailedInspection(unfinishedCar);
+                })
+                .withAttributes(ActorAttributes.withSupervisionStrategy(decider));
     }
 
     Flow<UnfinishedCar, Car, NotUsed> getInspect() {
@@ -27,5 +37,12 @@ class QualityAssurance {
         return unfinishedCar.getColor().isPresent() &&
                 unfinishedCar.getWheels().size() == 4 &&
                 unfinishedCar.getEngine().isPresent();
+    }
+
+    static class CarFailedInspection extends IllegalStateException {
+
+        public CarFailedInspection(UnfinishedCar unfinishedCar) {
+            super("The car " + unfinishedCar + " failed the inspection ");
+        }
     }
 }

--- a/exercises/src/test/resources/README.md
+++ b/exercises/src/test/resources/README.md
@@ -1,3 +1,3 @@
-working-with-flows
+fault-tolerance
 
 Please refer to the instructions in the Lightbend Academy.


### PR DESCRIPTION
Modify  Quality Assurance so that instead of filtering out any cars that did not meet standards, it will throw an exception and then handle that exception with an appropriate supervisor strategy (resume if CarFailedException stop if anything else).
Added tests