### PR TITLE
008_streams_telemetry_intro

### DIFF
--- a/exercises/src/main/java/com/lightbend/akkassembly/Akkassembly.java
+++ b/exercises/src/main/java/com/lightbend/akkassembly/Akkassembly.java
@@ -43,7 +43,7 @@ public class Akkassembly {
 
       long startTime = System.currentTimeMillis();
 
-      factory.orderCars(1000).thenAccept(cars -> {
+      factory.orderCars(10000).thenAccept(cars -> {
         long orderTime = System.currentTimeMillis() - startTime;
 
         System.out.println(cars.size() + " cars produced in "+orderTime+"ms");

--- a/exercises/src/main/java/com/lightbend/akkassembly/Auditor.java
+++ b/exercises/src/main/java/com/lightbend/akkassembly/Auditor.java
@@ -15,7 +15,6 @@ import java.util.concurrent.CompletionStage;
 
 class Auditor {
     private final Sink<Car, CompletionStage<Integer>> count;
-    //private final Materializer materializer;
     private final ActorSystem system;
 
 

--- a/exercises/src/main/java/com/lightbend/akkassembly/Factory.java
+++ b/exercises/src/main/java/com/lightbend/akkassembly/Factory.java
@@ -30,14 +30,13 @@ public class Factory {
 
     CompletionStage<List<Car>> orderCars(int quantity) {
         return bodyShop.getCars()
-                .via(paintShop.getPaint())
+                .via(paintShop.getPaint().named("paint-stage"))
+                .via(engineShop.getInstallEngine().named("install-engine-stage"))
                 .async()
-                .via(engineShop.getInstallEngine())
+                .via(wheelShop.getInstallWheels().named("install-wheels-stage"))
                 .async()
-                .via(wheelShop.getInstallWheels())
-                .async()
-                .via(upgradeShop.getInstallUpgrades())
-                .via(qualityAssurance.getInspect())
+                .via(upgradeShop.getInstallUpgrades().named("install-upgrades-stage"))
+                .via(qualityAssurance.getInspect().named("inspect-stage"))
                 .take(quantity)
                 .runWith(Sink.seq(), system);
     }

--- a/exercises/src/main/java/com/lightbend/akkassembly/UpgradeShop.java
+++ b/exercises/src/main/java/com/lightbend/akkassembly/UpgradeShop.java
@@ -1,11 +1,13 @@
 package com.lightbend.akkassembly;
 
 import akka.NotUsed;
-import akka.actor.Cancellable;
-import akka.stream.*;
-import akka.stream.javadsl.*;
-import com.typesafe.config.ConfigException;
-import scala.annotation.meta.field;
+import akka.stream.FlowShape;
+import akka.stream.UniformFanInShape;
+import akka.stream.UniformFanOutShape;
+import akka.stream.javadsl.Balance;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.GraphDSL;
+import akka.stream.javadsl.Merge;
 
 class UpgradeShop {
     private final Flow<UnfinishedCar, UnfinishedCar, NotUsed> installUpgrades;

--- a/exercises/src/main/resources/telemetry.conf
+++ b/exercises/src/main/resources/telemetry.conf
@@ -5,3 +5,11 @@ cinnamon.prometheus {
     port = 9001
   }
 }
+
+cinnamon.akka {
+  streams {
+    "com.lightbend.akkassembly.Factory.orderCars" {
+      report-by = instance
+    }
+  }
+}

--- a/exercises/src/test/resources/README.md
+++ b/exercises/src/test/resources/README.md
@@ -1,3 +1,3 @@
-fusion
+streams-telemetry-intro
 
 Please refer to the instructions in the Lightbend Academy.


### PR DESCRIPTION
In order to determine the busy times of stages we use Lightbend Telemetry
Selected the stream "com.lightbend.akkassembly.Factory.orderCars" (method whre Akkassembly stream is materialized: the runWith() method)
Metrics reported for each materialized individual stream instance using the report-by = instance setting.
Resulting metrics use an id created by the materializer for each stream instance, such as flow-0, flow-1, flow-2, etc.
Added tests